### PR TITLE
Fix Android autocorrect-submit-issue

### DIFF
--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -190,9 +190,12 @@ const DraftEditorCompositionHandler = {
       const {blockKey, decoratorKey, leafKey} =
         DraftOffsetKey.decode(offsetKey);
 
-      const {start, end} = editorState
+      const leafState = editorState
         .getBlockTree(blockKey)
         .getIn([decoratorKey, 'leaves', leafKey]);
+      if (!leafState) return;
+      
+      const {start, end} = leafState;
 
       const replacementRange = editorState.getSelection().merge({
         anchorKey: blockKey,


### PR DESCRIPTION
## Problem
In Android
- with **auto-correct ON**,
- when typing a **text that's yet to be autocorrected** (input some characters without ending with a space or hitting the suggestions)
- when submitting from an external event (e.g. on submit button click, not keyboard enter)
The draft-js lib throws an error as it cannot unwrap an undefined item.


## Solution
This PR adds a check for undefined to prevent unwrapping it.